### PR TITLE
6/product save error

### DIFF
--- a/src/app/code/community/IntegerNet/Solr/Model/Bridge/StoreEmulation.php
+++ b/src/app/code/community/IntegerNet/Solr/Model/Bridge/StoreEmulation.php
@@ -58,6 +58,7 @@ class IntegerNet_Solr_Model_Bridge_StoreEmulation implements StoreEmulation
 
         if ($this->_isEmulated && $this->_initialEnvironmentInfo) {
             Mage::getSingleton('core/app_emulation')->stopEnvironmentEmulation($this->_initialEnvironmentInfo);
+            $this->_isEmulated = false;
         }
     }
 

--- a/src/app/code/community/IntegerNet/Solr/Model/Resource/Catalog/Product/Indexing/Collection.php
+++ b/src/app/code/community/IntegerNet/Solr/Model/Resource/Catalog/Product/Indexing/Collection.php
@@ -9,6 +9,11 @@
  */
 class IntegerNet_Solr_Model_Resource_Catalog_Product_Indexing_Collection extends Mage_Catalog_Model_Resource_Product_Collection
 {
+    public function isEnabledFlat()
+    {
+        return false;
+    }
+
     /**
      * Join Product Price Table
      * Join left by default in order to include products without price index entry

--- a/src/app/code/community/IntegerNet/Solr/Model/Resource/Db.php
+++ b/src/app/code/community/IntegerNet/Solr/Model/Resource/Db.php
@@ -19,10 +19,24 @@ class IntegerNet_Solr_Model_Resource_Db
         /** @var Zend_Db_Adapter_Abstract $connection */
         foreach (Mage::getSingleton('core/resource')->getConnections() as $name => $connection) {
             if ($connection instanceof Zend_Db_Adapter_Abstract) {
+                if ($this->isTransactionOpen($connection)) {
+                    continue;
+                }
                 $connection->closeConnection();
             }
         }
         // connections (adapter objects) must be fully reinitialized, otherwise initStatements are not executed
         Mage::unregister('_singleton/core/resource');
+    }
+
+    /**
+     * Returns true if the given connection has open transactions
+     *
+     * @param Zend_Db_Adapter_Abstract $connection
+     * @return bool
+     */
+    private function isTransactionOpen(Zend_Db_Adapter_Abstract $connection)
+    {
+        return $connection instanceof Magento_Db_Adapter_Pdo_Mysql && $connection->isTransaction();
     }
 }

--- a/src/app/code/community/IntegerNet/Solr/Test/Controller/Abstract.php
+++ b/src/app/code/community/IntegerNet/Solr/Test/Controller/Abstract.php
@@ -12,7 +12,7 @@ abstract class IntegerNet_Solr_Test_Controller_Abstract extends EcomDev_PHPUnit_
 {
     public static function setUpBeforeClass()
     {
-        Mage::register('isSecureArea', true);
+        Mage::register('isSecureArea', true, true);
     }
     public static function tearDownAfterClass()
     {

--- a/src/app/code/community/IntegerNet/Solr/Test/Model/Indexer/Product.php
+++ b/src/app/code/community/IntegerNet/Solr/Test/Model/Indexer/Product.php
@@ -43,13 +43,13 @@ class IntegerNet_Solr_Test_Model_Indexer_Product extends IntegerNet_Solr_Test_Co
     {
         $this->setUpFreshIndex();
 
-        $this->setCurrentStore(0);
-        $this->adminSession();
+        $this->assertCount(0, $this->searchInStore(1, 'SUPERDUPER')->documents());
         $productId = 21001;
+        $this->setCurrentStore(0);
         $product = Mage::getModel('catalog/product')->load($productId);
         $product->setData('name', 'SUPERDUPER');
         $product->save();
-        $searchResponse = $this->searchFor('SUPERDUPER');
+        $searchResponse = $this->searchInStore(1, 'SUPERDUPER');
         $this->assertCount(1, $searchResponse->documents());
     }
 
@@ -57,9 +57,8 @@ class IntegerNet_Solr_Test_Model_Indexer_Product extends IntegerNet_Solr_Test_Co
      * @param $queryText
      * @return \IntegerNet\Solr\Resource\SolrResponse
      */
-    public function searchFor($queryText)
+    public function searchInStore($storeId, $queryText)
     {
-        $storeId = 1;
         $queryStub = $this->getMockBuilder(\IntegerNet\Solr\Implementor\HasUserQuery::class)
             ->getMockForAbstractClass();
         $queryStub->method('getUserQueryText')->willReturn($queryText);
@@ -79,7 +78,5 @@ class IntegerNet_Solr_Test_Model_Indexer_Product extends IntegerNet_Solr_Test_Co
     private function setUpFreshIndex()
     {
         Mage::getModel('integernet_solr/indexer')->reindexAll();
-        $indexProcess = Mage::getModel('index/process')->load('integernet_solr', 'indexer_code');
-        $indexProcess->setMode(Mage_Index_Model_Process::MODE_REAL_TIME)->save();
     }
 }

--- a/src/app/code/community/IntegerNet/Solr/Test/Model/Indexer/Product.php
+++ b/src/app/code/community/IntegerNet/Solr/Test/Model/Indexer/Product.php
@@ -43,9 +43,9 @@ class IntegerNet_Solr_Test_Model_Indexer_Product extends EcomDev_PHPUnit_Test_Ca
     {
         $this->setCurrentStore(0);
         $this->adminSession();
-        $productId = 1;
+        $productId = 21001;
         $product = Mage::getModel('catalog/product')->load($productId);
-        $product->setData('name', 'Product One SUPERDUPER');
+        $product->setData('name', 'SUPERDUPER');
         $product->save();
         $searchResponse = $this->searchFor('SUPERDUPER');
         $this->assertCount(1, $searchResponse->documents());

--- a/src/app/code/community/IntegerNet/Solr/Test/Model/Indexer/Product.php
+++ b/src/app/code/community/IntegerNet/Solr/Test/Model/Indexer/Product.php
@@ -67,6 +67,7 @@ class IntegerNet_Solr_Test_Model_Indexer_Product extends IntegerNet_Solr_Test_Co
         $applicationContext = $factory->getApplicationContext();
         $applicationContext->setFuzzyConfig($factory->getCurrentStoreConfig()->getFuzzySearchConfig());
         $applicationContext->setQuery($queryStub);
+        $applicationContext->setPagination(new \IntegerNet\Solr\Request\SinglePage(2));
         $searchRequestFactory = new \IntegerNet\Solr\Request\SearchRequestFactory(
             $applicationContext,
             $factory->getSolrResource(),

--- a/src/app/code/community/IntegerNet/Solr/Test/Model/Indexer/Product.php
+++ b/src/app/code/community/IntegerNet/Solr/Test/Model/Indexer/Product.php
@@ -35,4 +35,17 @@ class IntegerNet_Solr_Test_Model_Indexer_Product extends EcomDev_PHPUnit_Test_Ca
         Mage::helper('integernet_solr')->factory()->getProductIndexer()->reindex();
     }
 
+    /**
+     * @test
+     * @loadFixture catalog
+     */
+    public function saveProductShouldUpdateSolrIndex()
+    {
+        $this->setCurrentStore(0);
+        $this->adminSession();
+        $productId = 1;
+        $product = Mage::getModel('catalog/product')->load($productId);
+        $product->setData('name', 'Product One SUPERDUPER');
+        $product->save();
+    }
 }

--- a/src/app/code/community/IntegerNet/Solr/Test/Model/Indexer/Product.php
+++ b/src/app/code/community/IntegerNet/Solr/Test/Model/Indexer/Product.php
@@ -47,5 +47,29 @@ class IntegerNet_Solr_Test_Model_Indexer_Product extends EcomDev_PHPUnit_Test_Ca
         $product = Mage::getModel('catalog/product')->load($productId);
         $product->setData('name', 'Product One SUPERDUPER');
         $product->save();
+        $searchResponse = $this->searchFor('SUPERDUPER');
+        $this->assertCount(1, $searchResponse->documents());
+    }
+
+    /**
+     * @param $queryText
+     * @return \IntegerNet\Solr\Resource\SolrResponse
+     */
+    public function searchFor($queryText)
+    {
+        $storeId = 1;
+        $queryStub = $this->getMockBuilder(\IntegerNet\Solr\Implementor\HasUserQuery::class)
+            ->getMockForAbstractClass();
+        $queryStub->method('getUserQueryText')->willReturn($queryText);
+        $factory = Mage::helper('integernet_solr/factory');
+        $applicationContext = $factory->getApplicationContext();
+        $applicationContext->setFuzzyConfig($factory->getCurrentStoreConfig()->getFuzzySearchConfig());
+        $applicationContext->setQuery($queryStub);
+        $searchRequestFactory = new \IntegerNet\Solr\Request\SearchRequestFactory(
+            $applicationContext,
+            $factory->getSolrResource(),
+            $storeId
+        );
+        return $searchRequestFactory->createRequest()->doRequest();
     }
 }

--- a/src/app/code/community/IntegerNet/Solr/Test/Model/Indexer/Product.php
+++ b/src/app/code/community/IntegerNet/Solr/Test/Model/Indexer/Product.php
@@ -14,7 +14,7 @@ use IntegerNet\Solr\Resource\ResourceFacade;
  * @loadFixture registry
  * @loadFixture config
  */
-class IntegerNet_Solr_Test_Model_Indexer_Product extends EcomDev_PHPUnit_Test_Case_Controller
+class IntegerNet_Solr_Test_Model_Indexer_Product extends IntegerNet_Solr_Test_Controller_Abstract
 {
     /**
      * @param array $config
@@ -41,6 +41,8 @@ class IntegerNet_Solr_Test_Model_Indexer_Product extends EcomDev_PHPUnit_Test_Ca
      */
     public function saveProductShouldUpdateSolrIndex()
     {
+        $this->setUpFreshIndex();
+
         $this->setCurrentStore(0);
         $this->adminSession();
         $productId = 21001;
@@ -71,5 +73,12 @@ class IntegerNet_Solr_Test_Model_Indexer_Product extends EcomDev_PHPUnit_Test_Ca
             $storeId
         );
         return $searchRequestFactory->createRequest()->doRequest();
+    }
+
+    private function setUpFreshIndex()
+    {
+        Mage::getModel('integernet_solr/indexer')->reindexAll();
+        $indexProcess = Mage::getModel('index/process')->load('integernet_solr', 'indexer_code');
+        $indexProcess->setMode(Mage_Index_Model_Process::MODE_REAL_TIME)->save();
     }
 }

--- a/src/app/code/community/IntegerNet/Solr/Test/fixtures/registry.yaml
+++ b/src/app/code/community/IntegerNet/Solr/Test/fixtures/registry.yaml
@@ -7,6 +7,9 @@ registry:
     - integernet_solr/factory
     - integernet_solr/log
   singleton:
+    - eav/config
+    - core/app_emulation
+    - core/factory
     - catalog/layer
     - core/session
     - customer/session


### PR DESCRIPTION
Source of the product save bug was that during "update on save" the MySQL connection was closed within a transaction.

Tests have been added to make sure that update on save actually works. Additional bugs found by the tests, that may or may not have effect in production:

- store emulation status was not reset
- possible use of flat product index as source for solr index