### PR TITLE
Slices

### DIFF
--- a/src/app/code/community/IntegerNet/Solr/Model/Bridge/ProductRepository.php
+++ b/src/app/code/community/IntegerNet/Solr/Model/Bridge/ProductRepository.php
@@ -66,12 +66,22 @@ class IntegerNet_Solr_Model_Bridge_ProductRepository implements ProductRepositor
     }
 
     /**
+     * @param null|int $sliceId
+     * @param null|int $totalNumberSlices
      * @return int[]
      */
-    public function getAllProductIds()
+    public function getAllProductIds($sliceId = null, $totalNumberSlices = null)
     {
-        /** @var $productCollection Mage_Catalog_Model_Resource_Product_Collection */
         $productCollection = Mage::getResourceModel('catalog/product_collection');
+
+        /** @var $productCollection Mage_Catalog_Model_Resource_Product_Collection */
+        if ((!is_null($sliceId)) && (!is_null($totalNumberSlices))) {
+            if ($sliceId == $totalNumberSlices) {
+                $sliceId = 0;
+            }
+            $productCollection->getSelect()->where('e.entity_id % ' . intval($totalNumberSlices) . ' = ' . intval($sliceId));
+        }
+
         return $productCollection->getAllIds();
     }
 

--- a/src/app/code/community/IntegerNet/Solr/Model/Bridge/ProductRepository.php
+++ b/src/app/code/community/IntegerNet/Solr/Model/Bridge/ProductRepository.php
@@ -72,9 +72,9 @@ class IntegerNet_Solr_Model_Bridge_ProductRepository implements ProductRepositor
      */
     public function getAllProductIds($sliceId = null, $totalNumberSlices = null)
     {
+        /** @var $productCollection Mage_Catalog_Model_Resource_Product_Collection */
         $productCollection = Mage::getResourceModel('catalog/product_collection');
 
-        /** @var $productCollection Mage_Catalog_Model_Resource_Product_Collection */
         if ((!is_null($sliceId)) && (!is_null($totalNumberSlices))) {
             if ($sliceId == $totalNumberSlices) {
                 $sliceId = 0;

--- a/src/app/code/community/IntegerNet/Solr/Test/Model/Result.php
+++ b/src/app/code/community/IntegerNet/Solr/Test/Model/Result.php
@@ -95,7 +95,7 @@ class IntegerNet_Solr_Test_Model_Result extends EcomDev_PHPUnit_Test_Case_Contro
             )
         );
         $logMock->expects($this->at(4))->method('debug')->with(
-            'Filter Query: store_id:1 AND is_visible_in_search_i:1');
+            'Filter Query: content_type:product AND store_id:1 AND is_visible_in_search_i:1');
 
         /* @var Mage_Core_Block_Text $toolbar Not using actual toolbar block which reads from session */
         $toolbar = $this->app()->getLayout()->createBlock('core/text', 'product_list_toolbar');

--- a/src/shell/integernet-solr.php
+++ b/src/shell/integernet-solr.php
@@ -55,11 +55,11 @@ class IntegerNet_Solr_Shell extends Mage_Shell_Abstract
 
                     $indexer = Mage::helper('integernet_solr')->factory()->getProductIndexer();
 
-                    if ($this->getArg('use-swap-core')) {
+                    if ($this->getArg('use_swap_core')) {
                         $indexer->activateSwapCore();
                     }
                     $indexer->reindex(null, $emptyIndex, $storeIds, $sliceId, $totalNumberSlices);
-                    if ($this->getArg('use-swap-core')) {
+                    if ($this->getArg('use_swap_core')) {
                         $indexer->deactivateSwapCore();
                     }
 
@@ -94,8 +94,14 @@ class IntegerNet_Solr_Shell extends Mage_Shell_Abstract
             }
             $storeIds = $this->_getStoreIds($storeIdentifiers);
             $indexer = Mage::helper('integernet_solr')->factory()->getProductIndexer();
+            if ($this->getArg('use_swap_core')) {
+                $indexer->activateSwapCore();
+            }
             foreach($storeIds as $storeId) {
                 $indexer->clearIndex($storeId);
+            }
+            if ($this->getArg('use_swap_core')) {
+                $indexer->deactivateSwapCore();
             }
             $storeIdsString = implode(', ', $storeIds);
             echo "Solr product index cleared for Stores {$storeIdsString}.\n";
@@ -131,7 +137,7 @@ class IntegerNet_Solr_Shell extends Mage_Shell_Abstract
 Usage:  php -f integernet-solr.php -- [options]
         php -f integernet-solr.php -- reindex --stores de
         php -f integernet-solr.php -- reindex --stores all --emptyindex
-        php -f integernet-solr.php -- reindex --stores 1 --slice 1/5 --use-swap-core
+        php -f integernet-solr.php -- reindex --stores 1 --slice 1/5 --use_swap_core
         php -f integernet-solr.php -- clear --stores 1
 
   reindex           Reindex solr for given stores (see "stores" param)
@@ -140,11 +146,11 @@ Usage:  php -f integernet-solr.php -- [options]
   --noemptyindex    Force not emptying the solr index for the given store(s). If not set, configured value is used.
   --types <types>   Restrict indexing to certain entity types, i.e. "product", "category" or "page" (comma separated). Or "all". If not set, reindex products.
   --slice <number>/<total_number>, i.e. "1/5" or "2/5". Use this if you want to index only a part of the products, i.e. for letting indexing run in parallel (for products only).
-  --use-swap-core   Use swap core for indexing instead of live core (only if configured correctly). This is useful when using slices (see above), it's not needed otherwise.
+  --use_swap_core   Use swap core for indexing instead of live solr core (only if configured correctly) (for products only). This is useful if using slices (see above), it's not needed otherwise.
   
-  clear             Clear solr product index for given stores (see "stores" param)
+  clear             Clear solr product index for given stores (see "stores" param and "use_swap_core" param)
   
-  swap-cores        Swap cores. This is useful when using slices (see above) after indexing with the "--use-swap-core" param, it's not needed otherwise. See "stores" param.
+  swap-cores        Swap cores. This is useful if using slices (see above) after indexing with the "--use_swap_core" param; it's not needed otherwise. See "stores" param.
   
   help              This help
 


### PR DESCRIPTION
New functionality to index only a part of the products. You can choose how many parts ("slices") there are and which one you want to index. Additionaly, you can use the command line to clear the (swap) core or swap cores, so you can schedule your reindexing process yourself, even parallel to another indexing process.
Works with https://github.com/integer-net/solr-base/pull/4.