### PR TITLE
Indexing bug multistore

### DIFF
--- a/src/app/code/community/IntegerNet/Solr/Model/Bridge/ProductRepository.php
+++ b/src/app/code/community/IntegerNet/Solr/Model/Bridge/ProductRepository.php
@@ -70,6 +70,9 @@ class IntegerNet_Solr_Model_Bridge_ProductRepository implements ProductRepositor
      */
     public function getAllProductIds()
     {
+        // Fixes a bug with flat product collections called for different stores, see https://magento.stackexchange.com/q/30956/2207
+        Mage::unregister('_resource_singleton/catalog/product_flat');
+
         /** @var $productCollection Mage_Catalog_Model_Resource_Product_Collection */
         $productCollection = Mage::getResourceModel('catalog/product_collection');
         return $productCollection->getAllIds();

--- a/src/app/code/community/IntegerNet/Solr/Test/Model/Result.php
+++ b/src/app/code/community/IntegerNet/Solr/Test/Model/Result.php
@@ -95,7 +95,7 @@ class IntegerNet_Solr_Test_Model_Result extends EcomDev_PHPUnit_Test_Case_Contro
             )
         );
         $logMock->expects($this->at(4))->method('debug')->with(
-            'Filter Query: store_id:1 AND is_visible_in_search_i:1');
+            'Filter Query: content_type:product AND store_id:1 AND is_visible_in_search_i:1');
 
         /* @var Mage_Core_Block_Text $toolbar Not using actual toolbar block which reads from session */
         $toolbar = $this->app()->getLayout()->createBlock('core/text', 'product_list_toolbar');


### PR DESCRIPTION
Caused by a Magento core bug, if you had multiple store views and flat products enabled, only the products present in the store which was indexed first were being indexed. The bug is described in https://magento.stackexchange.com/questions/30956/loading-a-product-collection-through-multiple-stores.