### PR TITLE
Solr priority for outofstock products

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "homepage": "https://github.com/integer-net/solr-magento1",
   "require": {
     "aoepeople/aoe_layoutconditions": "~1.0.0",
-    "integer-net/solr-base": "~3.0.0"
+    "integer-net/solr-base": "dev-solr-priority-for-outofstock-products"
   },
   "require-dev": {
     "ecomdev/ecomdev_phpunit": "dev-dev",

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "homepage": "https://github.com/integer-net/solr-magento1",
   "require": {
     "aoepeople/aoe_layoutconditions": "~1.0.0",
-    "integer-net/solr-base": "~2.0.0"
+    "integer-net/solr-base": "~3.0.0"
   },
   "require-dev": {
     "ecomdev/ecomdev_phpunit": "dev-dev",

--- a/src/app/code/community/IntegerNet/Solr/Helper/Factory.php
+++ b/src/app/code/community/IntegerNet/Solr/Helper/Factory.php
@@ -101,6 +101,8 @@ class IntegerNet_Solr_Helper_Factory implements SolrRequestFactory
                 $this->getSolrResource(),
                 $storeId);
         } elseif ($isCategoryPage) {
+            $applicationContext
+                ->setCategoryConfig($this->getCurrentStoreConfig()->getCategoryConfig());
             $factory = new CategoryRequestFactory(
                 $applicationContext,
                 $this->getSolrResource(),

--- a/src/app/code/community/IntegerNet/Solr/Model/Config/Store.php
+++ b/src/app/code/community/IntegerNet/Solr/Model/Config/Store.php
@@ -163,7 +163,8 @@ final class IntegerNet_Solr_Model_Config_Store implements Config
                 $this->_getConfig($prefix . 'max_number_cms_page_suggestions'),
                 $this->_getConfigFlag($prefix . 'show_complete_category_path'),
                 $this->_getConfig($prefix . 'category_link_type'),
-                @unserialize($this->_getConfig($prefix . 'attribute_filter_suggestions'))
+                @unserialize($this->_getConfig($prefix . 'attribute_filter_suggestions')),
+                $this->_getConfig($prefix . 'show_outofstock')
             );
         }
         return $this->_autosuggest;
@@ -222,7 +223,7 @@ final class IntegerNet_Solr_Model_Config_Store implements Config
                 $this->_getConfig($prefix . 'max_price'),
                 $this->_getConfigFlag($prefix . 'use_custom_price_intervals'),
                 explode(',', $this->_getConfig($prefix . 'custom_price_intervals')),
-                $this->_getConfigFlag($prefix . 'show_category_filter')
+                $this->_getConfig($prefix . 'show_outofstock')
             );
         }
         return $this->_results;

--- a/src/app/code/community/IntegerNet/Solr/Model/Config/Store.php
+++ b/src/app/code/community/IntegerNet/Solr/Model/Config/Store.php
@@ -265,7 +265,8 @@ final class IntegerNet_Solr_Model_Config_Store implements Config
                 $this->_getConfigFlag($prefix . 'use_in_search_results'),
                 intval($this->_getConfig($prefix . 'max_number_results')),
                 $this->_getConfigFlag($prefix . 'fuzzy_is_active'),
-                floatval($this->_getConfig($prefix . 'fuzzy_sensitivity'))
+                floatval($this->_getConfig($prefix . 'fuzzy_sensitivity')),
+                $this->_getConfig($prefix . 'show_outofstock')
             );
         }
         return $this->_category;

--- a/src/app/code/community/IntegerNet/Solr/Test/Model/Result.php
+++ b/src/app/code/community/IntegerNet/Solr/Test/Model/Result.php
@@ -95,7 +95,7 @@ class IntegerNet_Solr_Test_Model_Result extends EcomDev_PHPUnit_Test_Case_Contro
             )
         );
         $logMock->expects($this->at(4))->method('debug')->with(
-            'Filter Query: content_type:product AND store_id:1 AND is_visible_in_search_i:1');
+            'Filter Query: content_type:product AND store_id:1 AND is_visible_in_search_i:1 AND -is_in_stock_i:0');
 
         /* @var Mage_Core_Block_Text $toolbar Not using actual toolbar block which reads from session */
         $toolbar = $this->app()->getLayout()->createBlock('core/text', 'product_list_toolbar');

--- a/src/app/code/community/IntegerNet/Solr/etc/config.xml
+++ b/src/app/code/community/IntegerNet/Solr/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <IntegerNet_Solr>
-            <version>1.7.3</version>
+            <version>1.7.4</version>
             <version_suffix />
         </IntegerNet_Solr>
     </modules>
@@ -257,6 +257,8 @@
                 <filter_position>1</filter_position>
                 <show_category_filter>1</show_category_filter>
                 <priority_categories>2</priority_categories>
+                <show_outofstock>1</show_outofstock>
+                <priority_outofstock>1</priority_outofstock>
                 <max_number_filter_options>0</max_number_filter_options>
                 <price_step_size>10</price_step_size>
                 <max_price>200</max_price>

--- a/src/app/code/community/IntegerNet/Solr/etc/system.xml
+++ b/src/app/code/community/IntegerNet/Solr/etc/system.xml
@@ -309,6 +309,25 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                         </priority_categories>
+                        <show_outofstock translate="label,comment">
+                            <label>Show products which are out of stock</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <sort_order>57</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                        </show_outofstock>
+                        <priority_outofstock translate="label,comment">
+                            <label>Solr Priority Multiplier for Products being out of Stock</label>
+                            <comment>0 = don't show at all, 1 = don't modify, anything between = lower priority</comment>
+                            <frontend_type>text</frontend_type>
+                            <validate>validate-number validate-zero-or-greater</validate>
+                            <sort_order>58</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                        </priority_outofstock>
                         <price_step_size translate="label,comment">
                             <label>Size of Price Steps</label>
                             <comment><![CDATA[i.e. 100]]></comment>

--- a/src/app/code/community/IntegerNet/Solr/sql/integernet_solr_setup/upgrade-1.7.3-1.7.4.php
+++ b/src/app/code/community/IntegerNet/Solr/sql/integernet_solr_setup/upgrade-1.7.3-1.7.4.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * integer_net Magento Module
+ *
+ * @category   IntegerNet
+ * @package    IntegerNet_Solr
+ * @copyright  Copyright (c) 2016 integer_net GmbH (http://www.integer-net.de/)
+ * @author     Andreas von Studnitz <avs@integer-net.de>
+ */
+
+/** @var Mage_Catalog_Model_Resource_Setup $installer */
+$installer = $this;
+
+$installer->startSetup();
+
+$installer->setConfigData('integernet_solr/results/show_outofstock', Mage::getStoreConfig('cataloginventory/options/show_out_of_stock'));
+$installer->setConfigData('integernet_solr/autosuggest/show_outofstock', Mage::getStoreConfig('cataloginventory/options/show_out_of_stock'));
+
+Mage::getModel('index/process')
+    ->load('integernet_solr', 'indexer_code')
+    ->setStatus(Mage_Index_Model_Process::STATUS_REQUIRE_REINDEX)
+    ->save();
+
+$installer->endSetup();

--- a/src/app/code/community/IntegerNet/Solr/sql/integernet_solr_setup/upgrade-1.7.3-1.7.4.php
+++ b/src/app/code/community/IntegerNet/Solr/sql/integernet_solr_setup/upgrade-1.7.3-1.7.4.php
@@ -15,6 +15,7 @@ $installer->startSetup();
 
 $installer->setConfigData('integernet_solr/results/show_outofstock', Mage::getStoreConfig('cataloginventory/options/show_out_of_stock'));
 $installer->setConfigData('integernet_solr/autosuggest/show_outofstock', Mage::getStoreConfig('cataloginventory/options/show_out_of_stock'));
+$installer->setConfigData('integernet_solr/category/show_outofstock', Mage::getStoreConfig('cataloginventory/options/show_out_of_stock'));
 
 Mage::getModel('index/process')
     ->load('integernet_solr', 'indexer_code')

--- a/src/app/locale/de_DE/IntegerNet_Solr.csv
+++ b/src/app/locale/de_DE/IntegerNet_Solr.csv
@@ -107,3 +107,6 @@
 "Sort Filter Options alphabetically","Filteroptionen alphabetisch sortieren"
 "By default, filters are sorted by number of results.","Filter sind standardmäßig nach Anzahl der Treffer sortiert."
 "Show category filter","Kategorie-Filter anzeigen"
+"Show products which are out of stock","Produkte anzeigen, die nicht auf Lager sind"
+"Solr Priority Multiplier for Products being out of Stock","Solr-Prioritäts-Multiplikator für ausverkaufte Produkte"
+"0 = don't show at all, 1 = don't modify, anything between = lower priority","0 = gar nicht anzeigen, 1 = wie Produkte auf Lager, alles dazwischen = niedrigere Priorität"


### PR DESCRIPTION
Show products which are out of stock depending on the configuration for search results, category pages and autosuggest results. Additionally, you can modify the priority of out-of-stock products so they are shown below the other products, setting a new configuration value. This PR belongs to a set of PRs to all related repositories.