### PR TITLE
Prevent output when disabled

### DIFF
--- a/src/app/code/community/IntegerNet/Solr/Block/Result/Layer/View.php
+++ b/src/app/code/community/IntegerNet/Solr/Block/Result/Layer/View.php
@@ -27,6 +27,10 @@ class IntegerNet_Solr_Block_Result_Layer_View extends Mage_Core_Block_Template
      */
     public function canShowBlock()
     {
+        if (!Mage::helper('integernet_solr')->module()->isActive()) {
+            return false;
+        }
+
         switch ($this->getNameInLayout()) {
             case 'catalogsearch.solr.leftnav':
                 return Mage::getStoreConfig('integernet_solr/results/filter_position') == CategoryConfig::FILTER_POSITION_LEFT;

--- a/src/app/code/community/IntegerNet/Solr/Model/Observer.php
+++ b/src/app/code/community/IntegerNet/Solr/Model/Observer.php
@@ -65,6 +65,10 @@ class IntegerNet_Solr_Model_Observer
      */
     public function coreBlockAbstractToHtmlBefore(Varien_Event_Observer $observer)
     {
+        if (!Mage::getStoreConfigFlag('integernet_solr/general/is_active')) {
+            return;
+        }
+
         $block = $observer->getBlock();
 
         // Add "Solr Priority" column to attribute grid

--- a/src/app/design/frontend/base/default/layout/integernet/solr/filter.xml
+++ b/src/app/design/frontend/base/default/layout/integernet/solr/filter.xml
@@ -41,7 +41,7 @@
                 <block type="integernet_solr/result_layer_state" name="catalogsearch.solr.topnav.layer.state" as="state" template="integernet/solr/layer/top/state.phtml"/>
                 <block type="integernet_solr/result_layer_filter" name="catalogsearch.solr.topnav.layer.filter" as="filter" template="integernet/solr/layer/top/filter.phtml"/>
             </block>
-            <block type="core/template" template="integernet/solr/loader.phtml" name="solr.loader" as="solr.loader"/>
+            <block ifconfig="integernet_solr/general/is_active" type="core/template" template="integernet/solr/loader.phtml" name="solr.loader" as="solr.loader"/>
         </reference>
     </catalogsearch_result_index>
 

--- a/src/app/design/frontend/base/default/template/integernet/solr/loader.phtml
+++ b/src/app/design/frontend/base/default/template/integernet/solr/loader.phtml
@@ -1,18 +1,20 @@
-<?php $style = $this->escapeHtml(trim(Mage::getStoreConfig('integernet_solr/solr_theme/loader_style'))); ?>
-<?php if($style == 'solr-system'): ?>
-    <div class="<?php echo $style ?>" id="solr-loader">
-        <div class="solr-system__notice"><?php echo $this->__('Loading...') ?></div>
-        <div class="solr-system__stars">
-            <div class="solr-system__star solr-system__star--sun"></div>
-            <div class="solr-system__star solr-system__star--mercury"></div>
-            <div class="solr-system__star solr-system__star--venus"></div>
-            <div class="solr-system__star solr-system__star--earth"></div>
-            <div class="solr-system__star solr-system__star--mars"></div>
+<?php if ( Mage::helper('integernet_solr')->module()->isActive() ): ?>
+    <?php $style = $this->escapeHtml(trim(Mage::getStoreConfig('integernet_solr/solr_theme/loader_style'))); ?>
+    <?php if ( $style == 'solr-system' ): ?>
+        <div class="<?php echo $style ?>" id="solr-loader">
+            <div class="solr-system__notice"><?php echo $this->__('Loading...') ?></div>
+            <div class="solr-system__stars">
+                <div class="solr-system__star solr-system__star--sun"></div>
+                <div class="solr-system__star solr-system__star--mercury"></div>
+                <div class="solr-system__star solr-system__star--venus"></div>
+                <div class="solr-system__star solr-system__star--earth"></div>
+                <div class="solr-system__star solr-system__star--mars"></div>
+            </div>
         </div>
-    </div>
-<?php else: ?>
-    <div class="solr-loader solr-loader--<?php echo $style ?>" id="solr-loader">
-        <div class="solr-loader--<?php echo $style ?>__notice"><?php echo $this->__('Loading...') ?></div>
-        <div class="solr-loader--<?php echo $style ?>__spinner"></div>
-    </div>
+    <?php else: ?>
+        <div class="solr-loader solr-loader--<?php echo $style ?>" id="solr-loader">
+            <div class="solr-loader--<?php echo $style ?>__notice"><?php echo $this->__('Loading...') ?></div>
+            <div class="solr-loader--<?php echo $style ?>__spinner"></div>
+        </div>
+    <?php endif; ?>
 <?php endif; ?>

--- a/src/app/design/frontend/rwd/default/layout/integernet/solr.xml
+++ b/src/app/design/frontend/rwd/default/layout/integernet/solr.xml
@@ -161,10 +161,10 @@
     <integernet_solr_result_index>
         <update handle="catalogsearch_result_index"/>
         <reference name="root">
-            <action method="setTemplate">
+            <action ifconfig="integernet_solr/general/is_active" method="setTemplate">
                 <name>integernet/solr/ajax/json.phtml</name>
             </action>
-            <block type="integernet_solr/result_layer_ajax" name="solr.json" as="json" />
+            <block ifconfig="integernet_solr/general/is_active" type="integernet_solr/result_layer_ajax" name="solr.json" as="json" />
         </reference>
         
         <remove name="right" />
@@ -175,7 +175,7 @@
     <integernet_solr_category_view>
         <update handle="catalog_category_view"/>
         <reference name="root">
-            <block type="integernet_solr/result_layer_ajax" name="solr.json" as="json" />
+            <block ifconfig="integernet_solr/general/is_active" type="integernet_solr/result_layer_ajax" name="solr.json" as="json" />
         </reference>
         
         <remove name="right" />

--- a/src/app/design/frontend/rwd/default/layout/integernet/solr/filter.xml
+++ b/src/app/design/frontend/rwd/default/layout/integernet/solr/filter.xml
@@ -52,7 +52,7 @@
                 <block type="integernet_solr/result_layer_renderers" name="catalogsearch.solr.topnav.layer.renderers"
                        as="state_renderers"/>
             </block>
-            <block type="core/template" template="integernet/solr/loader.phtml" name="solr.loader" as="solr.loader" after="-"/>
+            <block ifconfig="integernet_solr/general/is_active" type="core/template" template="integernet/solr/loader.phtml" name="solr.loader" as="solr.loader" after="-"/>
         </reference>
     </catalogsearch_result_index>
 


### PR DESCRIPTION
- Removes "Loading..." on category pages
- Removes layered navigation block and resulting error when solr is not reachable (only when module is disabled)