### PR TITLE
Adapt schema.xml to be compatible with solr7

### DIFF
--- a/solr_conf/schema.xml
+++ b/solr_conf/schema.xml
@@ -152,9 +152,9 @@
 
     <uniqueKey>id</uniqueKey>
 
-    <defaultSearchField>text</defaultSearchField>
+    <df>text</df>
 
-    <solrQueryParser defaultOperator="AND"/>
+    <solrQueryParser q.op="AND"/>
 
     <copyField source="*_t" dest="text"/>
     <copyField source="*_s" dest="text"/>


### PR DESCRIPTION
There are several changes to the schema.xml. Mostly long deprecated stuff was removed and that needed some changes. No node was really removed but only the naming changed.