### PR TITLE
Fix small bug with excluding filters on category pages

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -2,6 +2,12 @@ IntegerNet_Solr Free for Magento 1
 ===============
 Release Notes
 
+Upcoming
+--------------
+
+- Fix (unfuzzy) search request if fuzzy is activated and thus improve exact search results
+- Fix small bug with excluding filters on category pages (thanks Sven Härtwig!)
+
 Version 1.7.6 (Aug 16, 2017)
 ---------------
 

--- a/src/app/code/community/IntegerNet/Solr/Block/Result/Layer/View.php
+++ b/src/app/code/community/IntegerNet/Solr/Block/Result/Layer/View.php
@@ -90,7 +90,11 @@ class IntegerNet_Solr_Block_Result_Layer_View extends Mage_Core_Block_Template
                 if ($currentCategory) {
                     $removedFilterAttributeCodes = $currentCategory->getData('solr_remove_filters');
 
-                    if (is_array($removedFilterAttributeCodes) && in_array($attribute->getAttributeCode(), $removedFilterAttributeCodes)) {
+                    if (!is_array($removedFilterAttributeCodes)) {
+                        $removedFilterAttributeCodes = explode(',', $removedFilterAttributeCodes);
+                    }
+
+                    if (in_array($attribute->getAttributeCode(), $removedFilterAttributeCodes)) {
                         continue;
                     }
                 }


### PR DESCRIPTION
The multiselect field data was not exploded before so it didn't work
if more than one filter was selected.