### PR TITLE
fix for category attribute solr_remove_filters

### DIFF
--- a/src/app/code/community/IntegerNet/Solr/Model/Observer.php
+++ b/src/app/code/community/IntegerNet/Solr/Model/Observer.php
@@ -326,4 +326,28 @@ class IntegerNet_Solr_Model_Observer
 
         Mage::helper('integernet_solr')->factory()->getProductIndexer()->reindex($productIds);
     }
+
+    public function afterFlatCategoryLoadedUseBackendModel(Varien_Event_Observer $observer)
+    {
+        if (!Mage::getStoreConfigFlag('integernet_solr/general/is_active')) {
+            return;
+        }
+
+        /** @var Mage_Catalog_Model_Category $category */
+        $category = $observer->getCategory();
+
+        if (!$category || !$category->getId()) {
+            return;
+        }
+
+        if (Mage::helper('catalog/category_flat')->isEnabled() && !$category->getResource() instanceof Mage_Catalog_Model_Resource_Category_Flat) {
+            return;
+        }
+
+        $filtersToRemove = $category->getData('solr_remove_filters');
+
+        if ($filtersToRemove && !is_array($filtersToRemove)) {
+            $category->setData('solr_remove_filters', explode(',', $filtersToRemove));
+        }
+    }
 }

--- a/src/app/code/community/IntegerNet/Solr/etc/config.xml
+++ b/src/app/code/community/IntegerNet/Solr/etc/config.xml
@@ -230,6 +230,15 @@
                     </review>
                 </observers>
             </catalog_block_product_list_collection>
+            <catalog_category_load_after>
+                <observers>
+                    <integernet_solr>
+                        <type>singleton</type>
+                        <class>integernet_solr/observer</class>
+                        <method>afterFlatCategoryLoadedUseBackendModel</method>
+                    </integernet_solr>
+                </observers>
+            </catalog_category_load_after>
         </events>
     </frontend>
 


### PR DESCRIPTION
There is a problem with removed category filters. When category flats are on then backend model is not loaded for `solr_remove_filters`, functions: `IntegerNet_Solr_Block_Result_Layer_View::getFilters()` and  `IntegerNet_Solr_Block_Result_Layer_Filter::_getAttributeFilterItems()` don't works in a proper way.